### PR TITLE
Optimize getNearbyBlocks

### DIFF
--- a/src/de/jeffclan/AngelChest/PlayerListener.java
+++ b/src/de/jeffclan/AngelChest/PlayerListener.java
@@ -94,12 +94,6 @@ public class PlayerListener implements Listener {
 			List<Block> blocksNearby = Utils.getNearbyBlocks(angelChestBlock.getLocation(),
 					plugin.getConfig().getInt("max-radius"));
 
-			for (Block b : blocksNearby.toArray(new Block[blocksNearby.size()])) {
-				if (!b.getType().equals(Material.AIR) || b.getY() < 1) {
-					blocksNearby.remove(b);
-				}
-			}
-
 			if (blocksNearby.size() > 0) {
 				Collections.sort(blocksNearby, new Comparator<Block>() {
 					public int compare(Block b1, Block b2) {

--- a/src/de/jeffclan/AngelChest/Utils.java
+++ b/src/de/jeffclan/AngelChest/Utils.java
@@ -161,7 +161,10 @@ public class Utils {
 	        for(int x = location.getBlockX() - radius; x <= location.getBlockX() + radius; x++) {
 	            for(int y = location.getBlockY() - radius; y <= location.getBlockY() + radius; y++) {
 	                for(int z = location.getBlockZ() - radius; z <= location.getBlockZ() + radius; z++) {
-	                   blocks.add(location.getWorld().getBlockAt(x, y, z));
+			    Block block = location.getWorld().getBlockAt(x, y, z);
+                            if (block.getType().equals(Material.AIR) && block.getY() > 1) {
+                                blocks.add(block);
+                            }
 	                }
 	            }
 	        }


### PR DESCRIPTION
Instead of adding all blocks arround and then eliminates the blocks which are not not air (for example, when you die in the Ocean), only add the blocks that meet this condition ( AIR and y > 1 ) 

Adding all the blocks and then remove it makes no sense and overload the server thread, making it crash when there are so many other plugins/thread