### PR TITLE
Compare player UUIDs instead of player objects when attempting to restore inventory

### DIFF
--- a/src/de/jeffclan/AngelChest/PlayerListener.java
+++ b/src/de/jeffclan/AngelChest/PlayerListener.java
@@ -148,7 +148,7 @@ public class PlayerListener implements Listener {
 		// event.getPlayer().sendMessage("This is " + angelChest.owner.getName()+"'s
 		// AngelChest.");
 		// Test here if player is allowed to open THIS angelchest
-		if (angelChest.isProtected && !event.getPlayer().equals(angelChest.owner)
+		if (angelChest.isProtected && event.getPlayer().getUniqueId().compareTo(angelChest.owner.getUniqueId()) != 0
 				&& !event.getPlayer().hasPermission("angelchest.protect.ignore")) {
 			event.getPlayer().sendMessage(plugin.messages.MSG_NOT_ALLOWED_TO_OPEN_OTHER_ANGELCHESTS);
 			event.setCancelled(true);


### PR DESCRIPTION
Hi. A friend of mine opened #6 and asked me to fix it since you said you didn't have much time.

Some detail about this issue: the `Player` class does not implement `Object::equals(Object)` . Thus, it becomes an equality check for memory address (the default implementation of that method gets inherited). This works for when the player is online and doesn't leave the server, because the references point to the same object. However, when the player logs out, the server no longer keeps track of that player object (and in fact, it should be destroyed -- you are leaking memory with the way you are doing this by keeping a player loaded in memory while they do not exist and the server is expecting it to be garbage collected).

Consider refactoring your code to not use player objects where you can, and instead use UUIDs for comparisons and other operations like this to avoid a memory leak as aforementioned. I'm just fixing the bug that causes death chests to not be usable after logging out and back in, though that refactor should be easy enough. If there is ever a problem removing a chest or you forget to remove a reference somewhere, you'll end up leaking memory a lot -- especially on bigger servers (like big factions/pvp/etc servers) where people are probably dying more often.

This change is a simple one-liner to fix a specific bug, but if you have questions let me know.