### PR TITLE
Listen for additional block events

### DIFF
--- a/src/de/jeffclan/AngelChest/AngelChestPlugin.java
+++ b/src/de/jeffclan/AngelChest/AngelChestPlugin.java
@@ -68,7 +68,7 @@ public class AngelChestPlugin extends JavaPlugin {
 		
 		getServer().getPluginManager().registerEvents(new PlayerListener(this),this);
 		getServer().getPluginManager().registerEvents(new HologramListener(this),this);
-		getServer().getPluginManager().registerEvents(new BlockListener(this),  this);
+		getServer().getPluginManager().registerEvents(new BlockListener(this),this);
 		
 		@SuppressWarnings("unused")
 		Metrics metrics = new Metrics(this);

--- a/src/de/jeffclan/AngelChest/BlockListener.java
+++ b/src/de/jeffclan/AngelChest/BlockListener.java
@@ -5,6 +5,9 @@ import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 public class BlockListener implements Listener {
@@ -30,13 +33,44 @@ public class BlockListener implements Listener {
 	
 	@EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
-            for (Block block : event.blockList().toArray(new Block[event.blockList().size()])){
-                if(block.getType() == Material.CHEST){
-                   if(plugin.isAngelChest(block)) {
-                	   event.blockList().remove(block);
-                   }
-                }
-            }
+		for (Block block : event.blockList().toArray(new Block[event.blockList().size()])){
+			if(block.getType() == Material.CHEST){
+				if(plugin.isAngelChest(block)) {
+					event.blockList().remove(block);
+				}
+			}
+		}
     }
+	
+	@EventHandler
+    public void onBlockExplode(BlockExplodeEvent event) {
+		for (Block block : event.blockList().toArray(new Block[event.blockList().size()])){
+			if(block.getType() == Material.CHEST){
+				if(plugin.isAngelChest(block)) {
+					event.blockList().remove(block);
+				}
+			}
+		}
+	}
+	
+	@EventHandler
+    public void onBlockPistonExtendEvent(BlockPistonExtendEvent event) {
+		Block block = event.getBlock();
+		if(block.getType() == Material.CHEST){
+			if(plugin.isAngelChest(block)) {
+				event.setCancelled(true);
+			}
+		}
+	}
+	
+	@EventHandler
+    public void onBlockPistonRetractEvent(BlockPistonRetractEvent event) {
+		Block block = event.getBlock();
+		if(block.getType() == Material.CHEST){
+			if(plugin.isAngelChest(block)) {
+				event.setCancelled(true);
+			}
+		}
+	}
 	
 }


### PR DESCRIPTION
BlockExplodeEvent occurs when a player sleeps in a bed in the Nether/End and differs from EntityExplodeEvent and BlockBreakEvent. This can cause the AngelChest block to break, yet still exist as a java object causing players to lose their inventory permanently.

An additional check for pistons is added to prevent players from moving the chest which can break the plugin.