### PR TITLE
acfetch material mismatch fix

### DIFF
--- a/src/main/java/de/jeff_media/AngelChest/AngelChest.java
+++ b/src/main/java/de/jeff_media/AngelChest/AngelChest.java
@@ -74,9 +74,7 @@ public class AngelChest {
         //String hologramText = String.format(plugin.messages.HOLOGRAM_TEXT, plugin.getServer().getPlayer(owner).getName());
         String inventoryName = String.format(plugin.messages.ANGELCHEST_INVENTORY_NAME, plugin.getServer().getOfflinePlayer(owner).getName());
 
-        createChest(block,owner.toString());
-        String hologramText = String.format(plugin.messages.HOLOGRAM_TEXT, plugin.getServer().getOfflinePlayer(owner).getName());
-        hologram = new Hologram(block, hologramText, plugin);
+        createChest(block,owner);
 
         // Load OverflowInv
         overflowInv = Bukkit.createInventory(null, 54, inventoryName);
@@ -128,8 +126,7 @@ public class AngelChest {
 
         String inventoryName = String.format(plugin.messages.ANGELCHEST_INVENTORY_NAME, plugin.getServer().getPlayer(owner).getName());
         overflowInv = Bukkit.createInventory(null, 54, inventoryName);
-        createChest(block,p.getUniqueId().toString());
-        createHologram(block, plugin);
+        createChest(block,p.getUniqueId());
 
         // Remove curse of vanishing equipment and Minepacks backpacks
         for (ItemStack i : playerItems.getContents()) {
@@ -150,16 +147,22 @@ public class AngelChest {
         return YamlConfiguration.loadConfiguration(file);
     }
 
-
-
-    private void createChest(Block block, String uuid) {
+    // Creates a physcial chest
+    protected void createChest(Block block, UUID uuid) {
         block.setType(plugin.chestMaterial);
         if(plugin.chestMaterial==Material.PLAYER_HEAD) {
             Skull state = (Skull) block.getState();
-            state.setOwningPlayer(plugin.getServer().getOfflinePlayer(UUID.fromString(uuid)));
+            state.setOwningPlayer(plugin.getServer().getOfflinePlayer(uuid));
             state.update();
         }
+        createHologram(plugin, block, uuid);
+    }
 
+    // Destroys a physical chest
+    protected void destroyChest(Block b) {
+        b.setType(Material.AIR);
+        b.getLocation().getWorld().spawnParticle(Particle.EXPLOSION_NORMAL, b.getLocation(), 1);
+        destroyHologram(plugin);
     }
 
     public void unlock() {
@@ -212,8 +215,8 @@ public class AngelChest {
         if (!plugin.isAngelChest(block))
             return;
 
-        block.setType(Material.AIR);
-        destroyHologram(plugin);
+        // remove the physical chest
+        destroyChest(block);
 
         // drop contents
         Utils.dropItems(block, armorInv);
@@ -224,9 +227,6 @@ public class AngelChest {
         if (experience > 0) {
             Utils.dropExp(block, experience);
         }
-
-
-        block.getLocation().getWorld().spawnParticle(Particle.EXPLOSION_NORMAL, block.getLocation(), 1);
     }
 
     void remove() {
@@ -239,8 +239,8 @@ public class AngelChest {
 		return seconds;
     }*/
     
-	public void createHologram(Block block, Main plugin) {
-		String hologramText = String.format(plugin.messages.HOLOGRAM_TEXT, plugin.getServer().getPlayer(owner).getName());
+	public void createHologram(Main plugin, Block block, UUID uuid) {
+		String hologramText = String.format(plugin.messages.HOLOGRAM_TEXT, plugin.getServer().getOfflinePlayer(uuid).getName());
 		hologram = new Hologram(block, hologramText, plugin);
 	}
 

--- a/src/main/java/de/jeff_media/AngelChest/CommandFetch.java
+++ b/src/main/java/de/jeff_media/AngelChest/CommandFetch.java
@@ -1,10 +1,8 @@
 package de.jeff_media.AngelChest;
 
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.data.Directional;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -45,46 +43,58 @@ public class CommandFetch implements CommandExecutor {
 			return true;
 		}
 
-		Location pLoc = p.getLocation();
+		Location newLoc = p.getLocation();
 		String dir = Utils.getCardinalDirection(p);
-		BlockFace facing = BlockFace.NORTH;
-		if (dir == "N") {
-			pLoc.add(0,0,-2);
-			facing = BlockFace.SOUTH;
-		} else if (dir == "NE") {
-			pLoc.add(2,0,-2);
-			facing = BlockFace.SOUTH;
-		} else if (dir == "E") {
-			pLoc.add(2,0,0);
-			facing = BlockFace.WEST;
-		} else if (dir == "SE") {
-			pLoc.add(2,0,2);
-			facing = BlockFace.WEST;
-		} else if (dir == "S") {
-			pLoc.add(0,0,2);
-			facing = BlockFace.NORTH;
-		} else if (dir == "SW") {
-			pLoc.add(-2,0,2);
-			facing = BlockFace.NORTH;
-		} else if (dir == "W") {
-			pLoc.add(-2,0,0);
-			facing = BlockFace.EAST;
-		} else if (dir == "NW") {
-			pLoc.add(-2,0,-2);
-			facing = BlockFace.EAST;
+		BlockFace facing;
+	
+		// Set the relative direction of the block and offset the new chest location
+		switch(dir){
+			case "N":
+				newLoc.add(0,0,-2);
+				facing = BlockFace.SOUTH;
+				break;
+			case "NE":
+				newLoc.add(2,0,-2);
+				facing = BlockFace.SOUTH;
+				break;
+			case "E":
+				newLoc.add(2,0,0);
+				facing = BlockFace.WEST;
+				break;
+			case "SE":
+				newLoc.add(2,0,2);
+				facing = BlockFace.WEST;
+				break;
+			case "S":
+				newLoc.add(0,0,2);
+				facing = BlockFace.NORTH;
+				break;
+			case "SW":
+				newLoc.add(-2,0,2);
+				facing = BlockFace.NORTH;
+				break;
+			case "W":
+				newLoc.add(-2,0,0);
+				facing = BlockFace.EAST;
+				break;
+			case "NW":
+				newLoc.add(-2,0,-2);
+				facing = BlockFace.EAST;
+				break;
+			default:
+				plugin.getLogger().info("Unable to get block facing direction");
+				facing = BlockFace.NORTH;
 		}
 
-		Block newBlock = Utils.findSafeBlock(pLoc.getBlock(), plugin);
+		Block newBlock = Utils.findSafeBlock(newLoc.getBlock(), plugin);
 		Block oldBlock = ac.block;
-		
+
 		// Move the block in game
 		ac.destroyChest(oldBlock);
 		ac.createChest(newBlock, p.getUniqueId());
 
 		// Make the chest face the player
-		Directional blockData = ((Directional) newBlock.getBlockData());
-		blockData.setFacing(facing);
-		newBlock.setBlockData(blockData);
+		AngelChestCommandUtils.setBlockDirection(newBlock, facing);
 
 		// Swap the block in code
 		plugin.angelChests.put(newBlock, plugin.angelChests.remove(oldBlock));

--- a/src/main/java/de/jeff_media/AngelChest/CommandFetch.java
+++ b/src/main/java/de/jeff_media/AngelChest/CommandFetch.java
@@ -76,21 +76,17 @@ public class CommandFetch implements CommandExecutor {
 
 		Block newBlock = Utils.findSafeBlock(pLoc.getBlock(), plugin);
 		Block oldBlock = ac.block;
-
+		
 		// Move the block in game
-		oldBlock.setType(Material.AIR);
-		newBlock.setType(Material.CHEST);
+		ac.destroyChest(oldBlock);
+		ac.createChest(newBlock, p.getUniqueId());
 
 		// Make the chest face the player
 		Directional blockData = ((Directional) newBlock.getBlockData());
 		blockData.setFacing(facing);
 		newBlock.setBlockData(blockData);
 
-		// Move the hologram
-		ac.destroyHologram(plugin);
-		ac.createHologram(newBlock, plugin);
-
-		// Move the block in code
+		// Swap the block in code
 		plugin.angelChests.put(newBlock, plugin.angelChests.remove(oldBlock));
 		plugin.angelChests.get(newBlock).block = newBlock;
 


### PR DESCRIPTION
Have /acfetch reuse the same functions as the main program to delete and generate chests.

No need to convert UUIDs to strings and back between functions.

Offset the player more so it looks nice when using /actp and fix the camera vector.

/acfetch and /actp fails during block rotation check when angel chest material is set to non-chest block types. Enclose the directional get and set functions with try catches and always return a valid value.
